### PR TITLE
Spice of Life and Spice of Life: Carrot Edition Modules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "SpiceOfLife"]
+	path = SpiceOfLife
+	url = https://github.com/squeek502/SpiceOfLife

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "SpiceOfLife"]
-	path = SpiceOfLife
-	url = https://github.com/squeek502/SpiceOfLife

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,9 @@ version = "1.2.0-beta"
 group = "yeelp.scalingfeast" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "scalingfeast"
 
+sourceSets.main.java.srcDirs += 'java'
+sourceSets.main.java.srcDirs += 'SpiceOfLife/src'
+
 sourceCompatibility = targetCompatibility = '1.8' // Need this here so eclipse task generates correctly.
 compileJava {
     sourceCompatibility = targetCompatibility = '1.8'

--- a/build.gradle
+++ b/build.gradle
@@ -2,12 +2,17 @@ buildscript {
     repositories {
         jcenter()
         maven { url = "https://files.minecraftforge.net/maven" }
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath 'net.minecraftforge.gradle:ForgeGradle:2.3-SNAPSHOT'
+        classpath 'com.wynprice.cursemaven:CurseMaven:2.1.1'
     }
 }
 apply plugin: 'net.minecraftforge.gradle.forge'
+apply plugin: "com.wynprice.cursemaven"
 //Only edit below this line, the above code adds and enables the necessary things for Forge to be setup.
 
 
@@ -15,9 +20,6 @@ apply plugin: 'net.minecraftforge.gradle.forge'
 version = "1.2.0-beta"
 group = "yeelp.scalingfeast" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "scalingfeast"
-
-sourceSets.main.java.srcDirs += 'java'
-sourceSets.main.java.srcDirs += 'SpiceOfLife/src'
 
 sourceCompatibility = targetCompatibility = '1.8' // Need this here so eclipse task generates correctly.
 compileJava {
@@ -43,6 +45,7 @@ repositories {
 }
 dependencies {
 deobfCompile "applecore:AppleCore:1.12.2-3.2.0+335.2dbab:api"
+deobfProvided "curse.maven:spiceoflife:2571951"
     // you may put jars on which you depend on in ./libs
     // or you may define them like so..
     //compile "some.group:artifact:version:classifier"

--- a/src/main/java/yeelp/scalingfeast/ModConfig.java
+++ b/src/main/java/yeelp/scalingfeast/ModConfig.java
@@ -281,6 +281,10 @@ public class ModConfig
 					  "Values for r > 32767 will be brought inside these bounds modulo 32767. list entires that aren't of this form, or pairs containing negative values for either m or r will be silently ignored."})
 			@RequiresMcRestart
 			public String[] milestones = {"5:2", "10:2", "15:2", "20:2", "25:2", "30:2", "35:2", "40:2", "45:2", "50:2"};
+		
+			@Name("Reward Messages Above Hotbar?")
+			@Comment("If true, Scaling Feast will display its reward messages above a player's hotbar. Else, it will display it in chat.")
+			public boolean rewardMsgAboveHotbar = false;
 		}
 	}
 	

--- a/src/main/java/yeelp/scalingfeast/ModConfig.java
+++ b/src/main/java/yeelp/scalingfeast/ModConfig.java
@@ -234,11 +234,11 @@ public class ModConfig
 		@Comment("If true, the Hearty Shank will no longer increase max hunger")
 		public boolean isShankDisabled = false;
 		
-		@Name("Spice Of Life Module")
+		@Name("Spice Of Life")
 		@Comment("Tweak Spice Of Life integration")
 		public SpiceOfLifeCategory spiceoflife = new SpiceOfLifeCategory();
 		
-		@Name("Spice Of Life Carrot Edition Module")
+		@Name("Spice Of Life: Carrot Edition")
 		@Comment("Tweak Spice Of Life: Carrot Edition integration")
 		public SOLCarrotCategory sol = new SOLCarrotCategory();
 		
@@ -251,18 +251,21 @@ public class ModConfig
 			
 			@Name("Use Food Groups")
 			@Comment("Should Scaling Feast check food groups in a player's food history instead of individual food items? Must have food groups defined in Spice Of Life")
+			@RequiresMcRestart
 			public boolean useFoodGroups = false;
 			
 			@Name("Required Amount")
-			@Comment("How many unique entries must be found in a player's food history to prevent punishing them. Must be less than or equal to Spice of Life's food history length, or else this module will do nothing")
+			@Comment("How many unique entries must be found in a player's food history to prevent punishing them. Should be less than or equal to Spice of Life's food history length")
 			@RangeInt(min = 1)
+			@RequiresMcRestart
 			public int uniqueRequired = 5;
 			
 			@Name("Penalty")
 			@Comment({"If the number of unique entires in a player's food history is less than Required Amount, that player will lose this much max hunger for every unique entry missing.",
 					  "For example, if a player has 3 unique entires and the required amount is 5, they will lose (5-3)*(penalty) max hunger"})
 			@RangeInt(min = 1, max = Short.MAX_VALUE)
-			public int penalty = 1;
+			@RequiresMcRestart
+			public int penalty = 2;
 		}
 		
 		public static class SOLCarrotCategory

--- a/src/main/java/yeelp/scalingfeast/ModConfig.java
+++ b/src/main/java/yeelp/scalingfeast/ModConfig.java
@@ -11,6 +11,8 @@ import net.minecraftforge.fml.client.event.ConfigChangedEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import yeelp.scalingfeast.handlers.HUDOverlayHandler;
+import yeelp.scalingfeast.handlers.ModuleHandler;
+import yeelp.scalingfeast.helpers.SOLCarrotHelper;
 
 @Config(modid = ModConsts.MOD_ID)
 public class ModConfig 
@@ -252,7 +254,7 @@ public class ModConfig
 			public boolean useFoodGroups = false;
 			
 			@Name("Required Amount")
-			@Comment("How many unique entries must be found in a player's food history to prevent punishing them.")
+			@Comment("How many unique entries must be found in a player's food history to prevent punishing them. Must be less than or equal to Spice of Life's food history length, or else this module will do nothing")
 			@RangeInt(min = 1)
 			public int uniqueRequired = 5;
 			
@@ -274,6 +276,7 @@ public class ModConfig
 			@Comment({"A list of pairs delimited by a colon, m:r, of milestones and milestone rewards.",
 					  "When a player eats m unique food items, they will gain r max hunger, in half shanks. m must be a positive integer and r must be a positive integer less than 32767.",
 					  "Values for r > 32767 will be brought inside these bounds modulo 32767. list entires that aren't of this form, or pairs containing negative values for either m or r will be silently ignored."})
+			@RequiresMcRestart
 			public String[] milestones = {"5:2", "10:2", "15:2", "20:2", "25:2", "30:2", "35:2", "40:2", "45:2", "50:2"};
 		}
 	}
@@ -296,6 +299,7 @@ public class ModConfig
 				HUDOverlayHandler.loadColours();
 				HUDOverlayHandler.setIcons();
 				HUDOverlayHandler.loadTextColours();
+				SOLCarrotHelper.parseMilestones();
 			}
 		}
 	}

--- a/src/main/java/yeelp/scalingfeast/ModConfig.java
+++ b/src/main/java/yeelp/scalingfeast/ModConfig.java
@@ -30,6 +30,10 @@ public class ModConfig
 	@Name("HUD")
 	@Comment("These settings are for tweaking the heads-up display")
 	public static final HUDCategory hud = new HUDCategory();
+	
+	@Name("Modules")
+	@Comment("Enable and tweak Scaling Feast's behaviour with other mods")
+	public static final ModuleCategory modules = new ModuleCategory();
 
 	public static class FoodCapCategory
 	{
@@ -220,6 +224,58 @@ public class ModConfig
 				  "If the number of \'rows\' of saturation exceed the length of this list, it will wrap around to the beginning.",
 				  "If any invalid hex string is entered, it will be ignored."})
 		public String[] Scolours = {"d70000", "d700d7", "6400d7", "00d3d7", "64d700", "d7d700", "d7d7d7"}; 
+	}
+	
+	public static class ModuleCategory
+	{
+		@Name("Disable Hearty Shank Effects")
+		@Comment("If true, the Hearty Shank will no longer increase max hunger")
+		public boolean isShankDisabled = false;
+		
+		@Name("Spice Of Life Module")
+		@Comment("Tweak Spice Of Life integration")
+		public SpiceOfLifeCategory spiceoflife = new SpiceOfLifeCategory();
+		
+		@Name("Spice Of Life Carrot Edition Module")
+		@Comment("Tweak Spice Of Life: Carrot Edition integration")
+		public SOLCarrotCategory sol = new SOLCarrotCategory();
+		
+		public static class SpiceOfLifeCategory
+		{
+			@Name("Enabled")
+			@Comment("Set to true to enable the Spice Of Life module")
+			@RequiresMcRestart
+			public boolean enabled = false;
+			
+			@Name("Use Food Groups")
+			@Comment("Should Scaling Feast check food groups in a player's food history instead of individual food items? Must have food groups defined in Spice Of Life")
+			public boolean useFoodGroups = false;
+			
+			@Name("Required Amount")
+			@Comment("How many unique entries must be found in a player's food history to prevent punishing them.")
+			@RangeInt(min = 1)
+			public int uniqueRequired = 5;
+			
+			@Name("Penalty")
+			@Comment({"If the number of unique entires in a player's food history is less than Required Amount, that player will lose this much max hunger for every unique entry missing.",
+					  "For example, if a player has 3 unique entires and the required amount is 5, they will lose (5-3)*(penalty) max hunger"})
+			@RangeInt(min = 1, max = Short.MAX_VALUE)
+			public int penalty = 1;
+		}
+		
+		public static class SOLCarrotCategory
+		{
+			@Name("Enabled")
+			@Comment("Set to true to enable the Spice Of Life: Carrot Edition module")
+			@RequiresMcRestart
+			public boolean enabled = false;
+			
+			@Name("Milestones")
+			@Comment({"A list of pairs delimited by a colon, m:r, of milestones and milestone rewards.",
+					  "When a player eats m unique food items, they will gain r max hunger, in half shanks. m must be a positive integer and r must be a positive integer less than 32767.",
+					  "Values for r > 32767 will be brought inside these bounds modulo 32767. list entires that aren't of this form, or pairs containing negative values for either m or r will be silently ignored."})
+			public String[] milestones = {"5:2", "10:2", "15:2", "20:2", "25:2", "30:2", "35:2", "40:2", "45:2", "50:2"};
+		}
 	}
 	
 	@Mod.EventBusSubscriber(modid = ModConsts.MOD_ID)

--- a/src/main/java/yeelp/scalingfeast/ScalingFeast.java
+++ b/src/main/java/yeelp/scalingfeast/ScalingFeast.java
@@ -20,12 +20,16 @@ import yeelp.scalingfeast.handlers.CapabilityHandler;
 import yeelp.scalingfeast.handlers.EnchantmentHandler;
 import yeelp.scalingfeast.handlers.FoodHandler;
 import yeelp.scalingfeast.handlers.LootTableInjector;
+import yeelp.scalingfeast.handlers.ModuleHandler;
 import yeelp.scalingfeast.handlers.PacketHandler;
 import yeelp.scalingfeast.handlers.PotionHandler;
+import yeelp.scalingfeast.helpers.SOLCarrotHelper;
+import yeelp.scalingfeast.helpers.SpiceOfLifeHelper;
 import yeelp.scalingfeast.init.SFEnchantments;
 import yeelp.scalingfeast.init.SFPotion;
 import yeelp.scalingfeast.proxy.Proxy;
 import yeelp.scalingfeast.util.FoodCap;
+import yeelp.scalingfeast.util.FoodCapModifier;
 import yeelp.scalingfeast.util.StarvationTracker;
 
 @Mod(modid = ModConsts.MOD_ID, name = ModConsts.MOD_NAME, version = ModConsts.MOD_VERSION)
@@ -51,11 +55,20 @@ public class ScalingFeast
         {
         	info("Scaling Feast found AppleSkin!");
         }
+        if(hasSolCarrot)
+        {
+        	info("Scaling Feast found Spice of Life: Carrot Edition!");
+        }
+        if(hasSpiceOfLife)
+        {
+        	info("Scaling Feast found Spice of Life!");
+        }
         proxy.preInit();
         SFEnchantments.init();
         SFPotion.init();
         FoodCap.register();
         StarvationTracker.register();
+        FoodCapModifier.register();
         new CapabilityHandler().register();
         SFPotion.addBrewingRecipes();
         PacketHandler.init();
@@ -70,13 +83,22 @@ public class ScalingFeast
         new EnchantmentHandler().register();
         new PotionHandler().register();
         new LootTableInjector().register();
+        new ModuleHandler().register();
         info("Scaling Feast initialization complete!");
     }
     
     @EventHandler 
     public void postInit(FMLPostInitializationEvent event)
     {
-    	
+    	if(hasSolCarrot)
+    	{
+    		SOLCarrotHelper.init();
+    	}
+    	if(hasSpiceOfLife)
+    	{
+    		SpiceOfLifeHelper.init();
+    	}
+    	info("Scaling Feast post-initialization complete!");
     } 
     
     @EventHandler

--- a/src/main/java/yeelp/scalingfeast/ScalingFeast.java
+++ b/src/main/java/yeelp/scalingfeast/ScalingFeast.java
@@ -34,6 +34,8 @@ public class ScalingFeast
 
     public static Logger logger;
     public static boolean hasAppleSkin;
+    public static boolean hasSolCarrot;
+    public static boolean hasSpiceOfLife;
     
     @SidedProxy(clientSide = ModConsts.CLIENT_PROXY, serverSide = ModConsts.SERVER_PROXY)
     public static Proxy proxy;
@@ -43,6 +45,8 @@ public class ScalingFeast
     {
         logger = event.getModLog();
         hasAppleSkin = Loader.isModLoaded("appleskin");
+        hasSolCarrot = Loader.isModLoaded("solcarrot");
+        hasSpiceOfLife = Loader.isModLoaded("spiceoflife");
         if(hasAppleSkin)
         {
         	info("Scaling Feast found AppleSkin!");

--- a/src/main/java/yeelp/scalingfeast/blocks/HeartyFeastBlock.java
+++ b/src/main/java/yeelp/scalingfeast/blocks/HeartyFeastBlock.java
@@ -26,6 +26,7 @@ import squeek.applecore.api.food.ItemFoodProxy;
 import yeelp.scalingfeast.ModConsts;
 import yeelp.scalingfeast.ScalingFeast;
 import yeelp.scalingfeast.init.SFFood;
+import yeelp.scalingfeast.util.FoodCapModifierProvider;
 import yeelp.scalingfeast.util.FoodCapProvider;
 
 /**
@@ -83,7 +84,7 @@ public class HeartyFeastBlock extends BlockCake implements IEdibleBlock
 	@Override
 	public boolean onBlockActivated(@Nullable World world, @Nullable BlockPos pos, @Nullable IBlockState state, EntityPlayer player, @Nullable EnumHand hand, EnumFacing side, float hitX, float hitY, float hitZ)
 	{
-		this.food = player.getCapability(FoodCapProvider.capFoodStat, null).getMaxFoodLevel()/7;
+		this.food = player.getCapability(FoodCapProvider.capFoodStat, null).getMaxFoodLevel(player.getCapability(FoodCapModifierProvider.foodCapMod, null))/7;
 		this.sat = this.food/4 + 0.5f;
 		ScalingFeast.info("HEAL: "+this.food+", "+this.sat);
 		return this.eat(world, pos, state, player);

--- a/src/main/java/yeelp/scalingfeast/handlers/CapabilityHandler.java
+++ b/src/main/java/yeelp/scalingfeast/handlers/CapabilityHandler.java
@@ -56,6 +56,7 @@ public class CapabilityHandler extends Handler
 				fs.setFoodSaturationLevel(fs.getFoodLevel());
 			}
 		}
+		ModuleHandler.updatePlayer(player);
 	}
 	
 	@SubscribeEvent
@@ -108,12 +109,14 @@ public class CapabilityHandler extends Handler
 			syncTracker(evt.getEntityPlayer());
 		}
 		syncCap(evt.getEntityPlayer());
+		syncMod(evt.getEntityPlayer());
 	}
 	
 	public static void sync(EntityPlayer player)
 	{
 		syncCap(player);
 		syncTracker(player);
+		syncMod(player);
 	}
 	
 	public static void syncCap(EntityPlayer player)

--- a/src/main/java/yeelp/scalingfeast/handlers/FoodHandler.java
+++ b/src/main/java/yeelp/scalingfeast/handlers/FoodHandler.java
@@ -5,6 +5,7 @@ import squeek.applecore.api.food.FoodEvent;
 import squeek.applecore.api.hunger.HungerEvent;
 import squeek.applecore.api.hunger.StarvationEvent;
 import yeelp.scalingfeast.ModConfig;
+import yeelp.scalingfeast.util.FoodCapModifierProvider;
 import yeelp.scalingfeast.util.FoodCapProvider;
 import yeelp.scalingfeast.util.IFoodCap;
 import yeelp.scalingfeast.util.IStarvationTracker;
@@ -15,7 +16,7 @@ public class FoodHandler extends Handler
 	@SubscribeEvent
 	public void onGetMaxHunger(HungerEvent.GetMaxHunger evt)
 	{
-		evt.maxHunger = evt.player.getCapability(FoodCapProvider.capFoodStat, null).getMaxFoodLevel();
+		evt.maxHunger = evt.player.getCapability(FoodCapProvider.capFoodStat, null).getMaxFoodLevel(evt.player.getCapability(FoodCapModifierProvider.foodCapMod, null));
 	}
 	
 	//Even if this event is canceled, we probably want to tick the starvation tracker. This is fine, as it will only succeed if the food level is zero.
@@ -39,7 +40,7 @@ public class FoodHandler extends Handler
 				}
 				IFoodCap foodCap = evt.player.getCapability(FoodCapProvider.capFoodStat, null);
 				//if foodcap <= our lower bound, do nothing.
-				if(foodCap.getMaxFoodLevel() <= ModConfig.foodCap.starve.starveLowerCap)
+				if(foodCap.getUnmodifiedMaxFoodLevel() <= ModConfig.foodCap.starve.starveLowerCap)
 				{
 					return;
 				}

--- a/src/main/java/yeelp/scalingfeast/handlers/HUDOverlayHandler.java
+++ b/src/main/java/yeelp/scalingfeast/handlers/HUDOverlayHandler.java
@@ -322,7 +322,7 @@ public class HUDOverlayHandler extends Handler
 			if(player.getHeldItemMainhand().getItem() instanceof HeartyShankItem || foodValues.hunger > 0)
 			{
 				foodAddition = "+"+Integer.toString(Math.min(foodValues.hunger, max - player.getFoodStats().getFoodLevel()));
-				satAddition = "+"+Float.toString(foodValues.getSaturationIncrement(player));
+				satAddition = String.format("+%.1f",Float.toString(foodValues.getSaturationIncrement(player)));
 				if(player.getHeldItemMainhand().getItem() instanceof HeartyShankItem)
 				{
 					maxAddition = "+"+Integer.toString(ModConfig.foodCap.inc);

--- a/src/main/java/yeelp/scalingfeast/handlers/HUDOverlayHandler.java
+++ b/src/main/java/yeelp/scalingfeast/handlers/HUDOverlayHandler.java
@@ -31,6 +31,7 @@ import yeelp.scalingfeast.ScalingFeast;
 import yeelp.scalingfeast.init.SFPotion;
 import yeelp.scalingfeast.items.HeartyShankItem;
 import yeelp.scalingfeast.util.Colour;
+import yeelp.scalingfeast.util.FoodCapModifierProvider;
 import yeelp.scalingfeast.util.FoodCapProvider;
 import yeelp.scalingfeast.util.StarvationTrackerProvider;
 
@@ -209,7 +210,7 @@ public class HUDOverlayHandler extends Handler
 		boolean isHungerEffectActive = player.isPotionActive(MobEffects.HUNGER);
 		int hunger = player.getFoodStats().getFoodLevel();
 		float sat = player.getFoodStats().getSaturationLevel();
-		int max = player.getCapability(FoodCapProvider.capFoodStat, null).getMaxFoodLevel();
+		int max = player.getCapability(FoodCapProvider.capFoodStat, null).getMaxFoodLevel(player.getCapability(FoodCapModifierProvider.foodCapMod, null));
 		int ticks = player.getCapability(StarvationTrackerProvider.starvationTracker, null).getCount();
 		//Get the number of full bars to draw
 		int numBars = hunger/ModConsts.VANILLA_MAX_HUNGER;
@@ -311,7 +312,7 @@ public class HUDOverlayHandler extends Handler
 	{
 		int hunger = player.getFoodStats().getFoodLevel();
 		float sat = player.getFoodStats().getSaturationLevel();
-		int max = player.getCapability(FoodCapProvider.capFoodStat, null).getMaxFoodLevel();
+		int max = player.getCapability(FoodCapProvider.capFoodStat, null).getMaxFoodLevel(player.getCapability(FoodCapModifierProvider.foodCapMod, null));
 		String foodAddition = "";
 		String maxAddition = "";
 		String satAddition = "";

--- a/src/main/java/yeelp/scalingfeast/handlers/ModuleHandler.java
+++ b/src/main/java/yeelp/scalingfeast/handlers/ModuleHandler.java
@@ -1,0 +1,30 @@
+package yeelp.scalingfeast.handlers;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import net.minecraftforge.fml.common.Optional;
+import net.minecraftforge.fml.common.eventhandler.EventPriority;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import squeek.applecore.api.food.FoodEvent;
+import squeek.spiceoflife.foodtracker.FoodHistory;
+import squeek.spiceoflife.foodtracker.foodgroups.FoodGroup;
+import yeelp.scalingfeast.ModConfig;
+import yeelp.scalingfeast.helpers.SpiceOfLifeHelper;
+
+public class ModuleHandler extends Handler 
+{
+	@SubscribeEvent(priority = EventPriority.LOWEST)
+	@Optional.Method(modid = "spiceoflife")
+	public void onFoodEaten(FoodEvent.FoodEaten evt)
+	{
+		if(SpiceOfLifeHelper.isEnabled() && ModConfig.modules.spiceoflife.enabled)
+		{
+			Set<?> entries;
+			if(ModConfig.modules.spiceoflife.useFoodGroups)
+			{
+				entries = FoodHistory.get(evt.player).getDistinctFoodGroups();
+			}
+		}
+	}
+}

--- a/src/main/java/yeelp/scalingfeast/handlers/ModuleHandler.java
+++ b/src/main/java/yeelp/scalingfeast/handlers/ModuleHandler.java
@@ -4,13 +4,16 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.network.NetworkPlayerInfo;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.FoodStats;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import squeek.applecore.api.food.FoodEvent;
 import yeelp.scalingfeast.ModConfig;
+import yeelp.scalingfeast.ScalingFeast;
 import yeelp.scalingfeast.helpers.SOLCarrotHelper;
 import yeelp.scalingfeast.helpers.SpiceOfLifeHelper;
 import yeelp.scalingfeast.util.FoodCapModifierProvider;
+import yeelp.scalingfeast.util.FoodCapProvider;
 import yeelp.scalingfeast.util.IFoodCapModifier;
 
 public class ModuleHandler extends Handler 
@@ -28,11 +31,13 @@ public class ModuleHandler extends Handler
 		if(SpiceOfLifeHelper.isEnabled() && ModConfig.modules.spiceoflife.enabled)
 		{
 			mod += SpiceOfLifeHelper.getPenalty(player);
+			ScalingFeast.info("Penalty: "+mod);
 		}
 		if(SOLCarrotHelper.isEnabled() && ModConfig.modules.sol.enabled)
 		{
 			mod += SOLCarrotHelper.getReward(player);
 		}
+		ScalingFeast.info("mod: "+mod);
 		if(curr.getModifier() == mod)
 		{
 			return;
@@ -40,6 +45,16 @@ public class ModuleHandler extends Handler
 		else
 		{
 			curr.setModifier(mod);
+			int currMax = player.getCapability(FoodCapProvider.capFoodStat, null).getMaxFoodLevel(curr);
+			FoodStats fs = player.getFoodStats();
+			if(fs.getFoodLevel() > currMax)
+			{
+				fs.setFoodLevel(currMax);
+			}
+			if(fs.getSaturationLevel() > currMax)
+			{
+				fs.setFoodSaturationLevel(fs.getFoodLevel());
+			}
 			if(!player.world.isRemote)
 			{
 				CapabilityHandler.syncMod(player);

--- a/src/main/java/yeelp/scalingfeast/handlers/ModuleHandler.java
+++ b/src/main/java/yeelp/scalingfeast/handlers/ModuleHandler.java
@@ -1,29 +1,48 @@
 package yeelp.scalingfeast.handlers;
 
-import java.util.HashSet;
-import java.util.Set;
-
-import net.minecraftforge.fml.common.Optional;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.network.NetworkPlayerInfo;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.server.MinecraftServer;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import squeek.applecore.api.food.FoodEvent;
-import squeek.spiceoflife.foodtracker.FoodHistory;
-import squeek.spiceoflife.foodtracker.foodgroups.FoodGroup;
 import yeelp.scalingfeast.ModConfig;
+import yeelp.scalingfeast.helpers.SOLCarrotHelper;
 import yeelp.scalingfeast.helpers.SpiceOfLifeHelper;
+import yeelp.scalingfeast.util.FoodCapModifierProvider;
+import yeelp.scalingfeast.util.IFoodCapModifier;
 
 public class ModuleHandler extends Handler 
-{
+{	
 	@SubscribeEvent(priority = EventPriority.LOWEST)
-	@Optional.Method(modid = "spiceoflife")
 	public void onFoodEaten(FoodEvent.FoodEaten evt)
 	{
+		updatePlayer(evt.player);
+	}
+	
+	public static void updatePlayer(EntityPlayer player)
+	{
+		short mod = 0;
+		IFoodCapModifier curr = player.getCapability(FoodCapModifierProvider.foodCapMod, null);
 		if(SpiceOfLifeHelper.isEnabled() && ModConfig.modules.spiceoflife.enabled)
 		{
-			Set<?> entries;
-			if(ModConfig.modules.spiceoflife.useFoodGroups)
+			mod += SpiceOfLifeHelper.getPenalty(player);
+		}
+		if(SOLCarrotHelper.isEnabled() && ModConfig.modules.sol.enabled)
+		{
+			mod += SOLCarrotHelper.getReward(player);
+		}
+		if(curr.getModifier() == mod)
+		{
+			return;
+		}
+		else
+		{
+			curr.setModifier(mod);
+			if(!player.world.isRemote)
 			{
-				entries = FoodHistory.get(evt.player).getDistinctFoodGroups();
+				CapabilityHandler.syncMod(player);
 			}
 		}
 	}

--- a/src/main/java/yeelp/scalingfeast/handlers/ModuleHandler.java
+++ b/src/main/java/yeelp/scalingfeast/handlers/ModuleHandler.java
@@ -148,13 +148,11 @@ public class ModuleHandler extends Handler
 		if(SpiceOfLifeHelper.isEnabled() && ModConfig.modules.spiceoflife.enabled)
 		{
 			mod += SpiceOfLifeHelper.getPenalty(player);
-			ScalingFeast.info("Penalty: "+mod);
 		}
 		if(SOLCarrotHelper.isEnabled() && ModConfig.modules.sol.enabled)
 		{
 			mod += SOLCarrotHelper.getReward(player);
 		}
-		ScalingFeast.info("mod: "+mod);
 		if(curr.getModifier() == mod)
 		{
 			return;
@@ -164,8 +162,8 @@ public class ModuleHandler extends Handler
 			curr.setModifier(mod);
 			int currMax = player.getCapability(FoodCapProvider.capFoodStat, null).getMaxFoodLevel(curr);
 			FoodStats fs = player.getFoodStats();
-			ScalingFeast.info(Integer.toString(currMax));
-			ScalingFeast.info(Integer.toString(fs.getFoodLevel()));
+			//ScalingFeast.info(Integer.toString(currMax));
+			//ScalingFeast.info(Integer.toString(fs.getFoodLevel()));
 			if(fs.getFoodLevel() > currMax)
 			{
 				fs.setFoodLevel(currMax);

--- a/src/main/java/yeelp/scalingfeast/handlers/ModuleHandler.java
+++ b/src/main/java/yeelp/scalingfeast/handlers/ModuleHandler.java
@@ -23,6 +23,7 @@ import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.Side;
+import squeek.applecore.api.AppleCoreAPI;
 import squeek.applecore.api.food.FoodEvent;
 import yeelp.scalingfeast.ModConfig;
 import yeelp.scalingfeast.ScalingFeast;
@@ -94,11 +95,13 @@ public class ModuleHandler extends Handler
 				{
 					ITextComponent splash = new TextComponentTranslation("modules.scalingfeast.sol.splash"+SOLCarrotHelper.getRewardSplashNumber());
 					ITextComponent msg = new TextComponentTranslation("modules.scalingfeast.sol.reward", SOLCarrotHelper.getLastMilestoneReached(evt.player).getReward());
-					ITextComponent fullMsg = new TextComponentString(splash.getFormattedText() + msg.getFormattedText());
 					if(!ModConfig.modules.sol.rewardMsgAboveHotbar)
 					{
-						fullMsg.setStyle(new Style().setColor(TextFormatting.GREEN));
+						msg.setStyle(new Style().setColor(TextFormatting.GREEN));
+						splash.setStyle(new Style().setColor(TextFormatting.GREEN));
 					}
+					ITextComponent fullMsg = new TextComponentString(splash.getFormattedText() +" "+ msg.getFormattedText());
+					
 					evt.player.sendStatusMessage(fullMsg, ModConfig.modules.sol.rewardMsgAboveHotbar);
 					evt.player.world.playSound(null, evt.player.posX, evt.player.posY, evt.player.posZ, SoundEvents.ENTITY_PLAYER_LEVELUP, SoundCategory.PLAYERS, 1.0f, 1.0f);
 				}
@@ -118,7 +121,7 @@ public class ModuleHandler extends Handler
 	@SubscribeEvent
 	public void onTooltip(ItemTooltipEvent evt)
 	{
-		if(SpiceOfLifeHelper.isEnabled() && evt.getEntityPlayer() != null && evt.getItemStack() != null && evt.getItemStack().getItem() instanceof ItemFood)
+		if(SpiceOfLifeHelper.isEnabled() && evt.getEntityPlayer() != null && evt.getItemStack() != null && AppleCoreAPI.accessor.isFood(evt.getItemStack()))
 		{
 			SpiceOfLifeHelper.ToolTipType type = SpiceOfLifeHelper.getToolTipType(evt.getItemStack(), evt.getEntityPlayer());
 			if(type != null)

--- a/src/main/java/yeelp/scalingfeast/handlers/PacketHandler.java
+++ b/src/main/java/yeelp/scalingfeast/handlers/PacketHandler.java
@@ -4,6 +4,7 @@ import net.minecraftforge.fml.common.network.simpleimpl.SimpleNetworkWrapper;
 import net.minecraftforge.fml.relauncher.Side;
 import yeelp.scalingfeast.ModConsts;
 import yeelp.scalingfeast.network.FoodCapMessage;
+import yeelp.scalingfeast.network.FoodCapModifierMessage;
 import yeelp.scalingfeast.network.StarvationTrackerMessage;
 
 public class PacketHandler 
@@ -14,5 +15,6 @@ public class PacketHandler
 	{
 		INSTANCE.registerMessage(FoodCapMessage.Handler.class, FoodCapMessage.class, id++, Side.CLIENT);
 		INSTANCE.registerMessage(StarvationTrackerMessage.Handler.class, StarvationTrackerMessage.class, id++, Side.CLIENT);
+		INSTANCE.registerMessage(FoodCapModifierMessage.Handler.class, FoodCapModifierMessage.class, id++, Side.CLIENT);
 	}
 }

--- a/src/main/java/yeelp/scalingfeast/helpers/ModuleNotLoadedException.java
+++ b/src/main/java/yeelp/scalingfeast/helpers/ModuleNotLoadedException.java
@@ -1,0 +1,9 @@
+package yeelp.scalingfeast.helpers;
+
+public class ModuleNotLoadedException extends Exception 
+{
+	public ModuleNotLoadedException(String msg)
+	{
+		super(msg);
+	}
+}

--- a/src/main/java/yeelp/scalingfeast/helpers/SOLCarrotHelper.java
+++ b/src/main/java/yeelp/scalingfeast/helpers/SOLCarrotHelper.java
@@ -1,0 +1,94 @@
+package yeelp.scalingfeast.helpers;
+
+import java.lang.reflect.InvocationTargetException;
+
+import net.minecraft.entity.player.EntityPlayer;
+import yeelp.scalingfeast.ScalingFeast;
+
+/**
+ * Helper class for Spice of Life: Carrot Edition integration.
+ * Uses reflection.
+ * @author Yeelp
+ *
+ */
+public final class SOLCarrotHelper 
+{
+	private static Class sol;
+	private static boolean enabled;
+	
+	/**
+	 * Initialize this module
+	 */
+	public static void init()
+	{
+		if(ScalingFeast.hasSolCarrot)
+		{
+			try 
+			{
+				sol = Class.forName("com.cazsius.solcarrot.tracking.FoodList");
+				enabled = true;
+			} 
+			catch (ClassNotFoundException e) 
+			{
+				ScalingFeast.err("Scaling Feast encountered problems trying to find Spice of Life: Carrot Edition. Check your installation and try again.");
+				e.printStackTrace();
+				enabled = false;
+			}
+		}
+		else
+		{
+			ScalingFeast.err("Spice of Life: Carrot Edition not found! This module will be disabled!");
+			enabled = false;
+		}
+	}
+	/**
+	 * Has the module loaded successfully?
+	 * @return true if Scaling Feast found Spice of Life: Carrot Edition, and found the SOLCarrotAPI class.
+	 */
+	public static boolean isEnabled()
+	{
+		return enabled;
+	}
+	/**
+	 * Get the FoodList length for this player.
+	 * @param player the player to get the FoodList of.
+	 * @return The length of the FoodList for this player.
+	 * @throws ModuleNotLoadedException If this module is not loaded.
+	 */
+	public static int getFoodListLength(EntityPlayer player) throws ModuleNotLoadedException
+	{
+		if(enabled)
+		{
+			try 
+			{
+				Object foodList = sol.cast(sol.getMethod("get", EntityPlayer.class).invoke(null, player));
+				return ((Integer)(sol.getMethod("getEatenFoodCount").invoke(foodList))).intValue();
+			} 
+			catch (NoSuchMethodException e) 
+			{
+				e.printStackTrace();
+			} 
+			catch (SecurityException e)
+			{
+				e.printStackTrace();
+			} 
+			catch (IllegalAccessException e) 
+			{
+				e.printStackTrace();
+			} 
+			catch (IllegalArgumentException e) 
+			{
+				e.printStackTrace();
+			} 
+			catch (InvocationTargetException e)
+			{
+				e.printStackTrace();
+			}
+			return -1;
+		}
+		else
+		{
+			throw new ModuleNotLoadedException("Spice of Life: Carrot Edition Module not loaded!");
+		}
+	}
+}

--- a/src/main/java/yeelp/scalingfeast/helpers/SOLCarrotHelper.java
+++ b/src/main/java/yeelp/scalingfeast/helpers/SOLCarrotHelper.java
@@ -41,6 +41,7 @@ public final class SOLCarrotHelper
 			enabled = false;
 		}
 	}
+	
 	/**
 	 * Has the module loaded successfully?
 	 * @return true if Scaling Feast found Spice of Life: Carrot Edition, and found the SOLCarrotAPI class.

--- a/src/main/java/yeelp/scalingfeast/helpers/SpiceOfLifeHelper.java
+++ b/src/main/java/yeelp/scalingfeast/helpers/SpiceOfLifeHelper.java
@@ -1,0 +1,78 @@
+package yeelp.scalingfeast.helpers;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import net.minecraft.entity.player.EntityPlayer;
+import squeek.spiceoflife.foodtracker.FoodEaten;
+import squeek.spiceoflife.foodtracker.FoodHistory;
+import yeelp.scalingfeast.ScalingFeast;
+
+/**
+ * Spice of Life helper class for Spice of Life integration.
+ * @author Yeelp
+ *
+ */
+public class SpiceOfLifeHelper 
+{	
+	
+	private static boolean enabled;
+	/**
+	 * Initialize this module
+	 */
+	public static void init()
+	{
+		if(ScalingFeast.hasSpiceOfLife)
+		{
+			enabled = true;
+		}
+		else
+		{
+			ScalingFeast.err("ScalingFeast encountered a problem trying to find Spice of Life. Check your installation, and try again.");
+			enabled = false;
+		}
+	}
+	
+	/**
+	 * Get a list of foods eaten by a player
+	 * @param player the player to target
+	 * @return a List of FoodEaten objects containing foods eaten by the specified player.
+	 * @throws ModuleNotLoadedException If this module isn't loaded yet.
+	 */
+	public static List<FoodEaten> getEatenFoodsFor(EntityPlayer player) throws ModuleNotLoadedException
+	{
+		if(enabled)
+		{
+			FoodHistory history = FoodHistory.get(player);
+			return history.getHistory();
+		}
+		else
+		{
+			throw new ModuleNotLoadedException("Spice of Life Module not loaded!");
+		}
+	}
+	
+	/**
+	 * Gets a Set of unique foods eaten by this player in their FoodHistory
+	 * @param player the player to get unique foods for
+	 * @return A Set of FoodEaten objects, containing unique foods eaten by the specified player
+	 * @throws ModuleNotLoadedException If this module hasn't been loaded
+	 */
+	public static Set<FoodEaten> getUniqueFoodsFor(EntityPlayer player) throws ModuleNotLoadedException
+	{
+		if(enabled)
+		{
+			HashSet<FoodEaten> foods = new HashSet<FoodEaten>();
+			for(FoodEaten f : getEatenFoodsFor(player))
+			{
+				foods.add(f);
+			}
+			return foods;
+		}
+		else
+		{
+			throw new ModuleNotLoadedException("Spice of Life Module not enabled!");
+		}
+	}
+}

--- a/src/main/java/yeelp/scalingfeast/helpers/SpiceOfLifeHelper.java
+++ b/src/main/java/yeelp/scalingfeast/helpers/SpiceOfLifeHelper.java
@@ -86,7 +86,6 @@ public class SpiceOfLifeHelper
 			for(FoodEaten f : getEatenFoodsFor(player))
 			{
 				foods.add(f.itemStack.getItem());
-				ScalingFeast.info(f.itemStack.getItem().getUnlocalizedName());
 			}
 			return foods;
 		}

--- a/src/main/java/yeelp/scalingfeast/helpers/SpiceOfLifeHelper.java
+++ b/src/main/java/yeelp/scalingfeast/helpers/SpiceOfLifeHelper.java
@@ -1,5 +1,6 @@
 package yeelp.scalingfeast.helpers;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -7,6 +8,7 @@ import java.util.Set;
 import net.minecraft.entity.player.EntityPlayer;
 import squeek.spiceoflife.foodtracker.FoodEaten;
 import squeek.spiceoflife.foodtracker.FoodHistory;
+import yeelp.scalingfeast.ModConfig;
 import yeelp.scalingfeast.ScalingFeast;
 
 /**
@@ -82,6 +84,42 @@ public class SpiceOfLifeHelper
 		else
 		{
 			throw new ModuleNotLoadedException("Spice of Life Module not enabled!");
+		}
+	}
+	
+	/**
+	 * Get the max hunger penalty for a player
+	 * @param player the player to get the max hunger penalty for
+	 * @return the max hunger penalty for the specified player, or 0 if the player has no penalty
+	 */
+	public static short getPenalty(EntityPlayer player)
+	{
+		Set<?> entries = new HashSet<Object>();
+		if(ModConfig.modules.spiceoflife.useFoodGroups)
+		{
+			entries = FoodHistory.get(player).getDistinctFoodGroups();
+		}
+		else
+		{
+			try 
+			{
+				entries = SpiceOfLifeHelper.getUniqueFoodsFor(player);
+			} 
+			catch (ModuleNotLoadedException e) 
+			{
+				ScalingFeast.err("Scaling Feast expected Spice of Life to be loaded, but it wasn't! This doesn't make any sense!");
+				ScalingFeast.err(Arrays.toString(e.getStackTrace()));
+				return 0;
+			}
+		}
+		int diff = ModConfig.modules.spiceoflife.uniqueRequired - entries.size();
+		if(diff <= 0 || entries.size() < ModConfig.modules.spiceoflife.uniqueRequired)
+		{
+			return 0;
+		}
+		else
+		{
+			return (short) (-1*(diff)*ModConfig.modules.spiceoflife.penalty);
 		}
 	}
 }

--- a/src/main/java/yeelp/scalingfeast/helpers/SpiceOfLifeHelper.java
+++ b/src/main/java/yeelp/scalingfeast/helpers/SpiceOfLifeHelper.java
@@ -35,6 +35,15 @@ public class SpiceOfLifeHelper
 	}
 	
 	/**
+	 * Is this module enabled?
+	 * @return true if enabled, false otherwise
+	 */
+	public static boolean isEnabled()
+	{
+		return enabled;
+	}
+	
+	/**
 	 * Get a list of foods eaten by a player
 	 * @param player the player to target
 	 * @return a List of FoodEaten objects containing foods eaten by the specified player.

--- a/src/main/java/yeelp/scalingfeast/items/HeartyShankItem.java
+++ b/src/main/java/yeelp/scalingfeast/items/HeartyShankItem.java
@@ -42,8 +42,11 @@ public class HeartyShankItem extends ItemFood
 	@SideOnly(Side.CLIENT)
 	public void addInformation(ItemStack stack, @Nullable World worldIn, List<String> tooltip, ITooltipFlag flagIn)
 	{
-		tooltip.add("Eat this to gain " + ModConfig.foodCap.inc/2.0f + " hunger shanks");
-		tooltip.add("added to your overall max hunger!");
+		if(!ModConfig.modules.isShankDisabled)
+		{
+			tooltip.add("Eat this to gain " + ModConfig.foodCap.inc/2.0f + " hunger shanks");
+			tooltip.add("added to your overall max hunger!");
+		}
 	}
 	
 	public int getMaxItemUseDuration(ItemStack stack)

--- a/src/main/java/yeelp/scalingfeast/items/HeartyShankItem.java
+++ b/src/main/java/yeelp/scalingfeast/items/HeartyShankItem.java
@@ -51,12 +51,12 @@ public class HeartyShankItem extends ItemFood
 	
 	public ItemStack onItemUseFinish(ItemStack stack, World worldIn, EntityLivingBase entityLiving)
 	{
-		if(entityLiving instanceof EntityPlayer)
+		if(entityLiving instanceof EntityPlayer && !ModConfig.modules.isShankDisabled)
 		{
 			IFoodCap currCap = ((EntityPlayer)entityLiving).getCapability(FoodCapProvider.capFoodStat, null);
-			if(ModConfig.foodCap.globalCap == -1 || ModConfig.foodCap.globalCap > currCap.getMaxFoodLevel())
+			if(ModConfig.foodCap.globalCap == -1 || ModConfig.foodCap.globalCap > currCap.getUnmodifiedMaxFoodLevel())
 			{
-				if(currCap.getMaxFoodLevel() + ModConfig.foodCap.inc > ModConfig.foodCap.globalCap && ModConfig.foodCap.globalCap != -1)
+				if(currCap.getUnmodifiedMaxFoodLevel() + ModConfig.foodCap.inc > ModConfig.foodCap.globalCap && ModConfig.foodCap.globalCap != -1)
 				{
 					currCap.setMax((short) ModConfig.foodCap.globalCap);
 				}

--- a/src/main/java/yeelp/scalingfeast/items/HeartyShankItem.java
+++ b/src/main/java/yeelp/scalingfeast/items/HeartyShankItem.java
@@ -8,8 +8,10 @@ import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.SoundEvents;
 import net.minecraft.item.ItemFood;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.SoundCategory;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -63,6 +65,7 @@ public class HeartyShankItem extends ItemFood
 				else
 				{
 					currCap.increaseMax((short)ModConfig.foodCap.inc);
+					worldIn.playSound(null, entityLiving.posX, entityLiving.posY, entityLiving.posZ, SoundEvents.ENTITY_ARROW_HIT_PLAYER, SoundCategory.PLAYERS, 1.0f, 1.0f);
 				}
 				if(ModConfig.foodCap.starve.shankResetsCounter)
 				{

--- a/src/main/java/yeelp/scalingfeast/network/FoodCapModifierMessage.java
+++ b/src/main/java/yeelp/scalingfeast/network/FoodCapModifierMessage.java
@@ -11,28 +11,23 @@ import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
 import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
-import yeelp.scalingfeast.ScalingFeast;
-import yeelp.scalingfeast.util.FoodCapProvider;
-import yeelp.scalingfeast.util.IFoodCap;
+import yeelp.scalingfeast.util.FoodCapModifierProvider;
+import yeelp.scalingfeast.util.IFoodCapModifier;
 
 /**
- * Scaling Feast's message for a player's food cap
+ * Scaling Feast's message for FoodCap modifiers
  * @author Yeelp
  *
  */
-public class FoodCapMessage implements IMessage
+public class FoodCapModifierMessage implements IMessage
 {
 	private NBTTagShort tag;
-	/**
-	 * Construct a new message.
-	 * @param cap The food cap for this message.
-	 */
-	public FoodCapMessage(IFoodCap cap)
+	public FoodCapModifierMessage(IFoodCapModifier mod)
 	{
-		this.tag = new NBTTagShort(cap.getUnmodifiedMaxFoodLevel());
+		this.tag = new NBTTagShort(mod.getModifier());
 	}
 	
-	public FoodCapMessage()
+	public FoodCapModifierMessage()
 	{
 		
 	}
@@ -48,28 +43,30 @@ public class FoodCapMessage implements IMessage
 	}
 	
 	/**
-	 * The Handler for the FoodCapMessage
+	 * The FoodCapModifierMessage handler
 	 * @author Yeelp
 	 *
 	 */
-	public static final class Handler implements IMessageHandler<FoodCapMessage, IMessage>
-	{	
-		
+	public static final class Handler implements IMessageHandler<FoodCapModifierMessage, IMessage>
+	{
+
 		@Override
 		@SideOnly(Side.CLIENT)
-		public IMessage onMessage(FoodCapMessage message, MessageContext ctx) 
+		public IMessage onMessage(FoodCapModifierMessage message, MessageContext ctx) 
 		{
 			FMLCommonHandler.instance().getWorldThread(ctx.netHandler).addScheduledTask(() -> handle(message, ctx));
 			return null;
 		}
 		
 		@SideOnly(Side.CLIENT)
-		public void handle(FoodCapMessage msg, MessageContext ctx)
+		public void handle(FoodCapModifierMessage msg, MessageContext ctx)
 		{
 			EntityPlayer player = Minecraft.getMinecraft().player;
-			player.getCapability(FoodCapProvider.capFoodStat, null).deserializeNBT((NBTTagShort) msg.serializeNBT());
+			player.getCapability(FoodCapModifierProvider.foodCapMod, null).deserializeNBT((NBTTagShort) msg.serializeNBT());
 		}
+		
 	}
+	
 	@Override
 	public void fromBytes(ByteBuf buf) 
 	{
@@ -80,4 +77,5 @@ public class FoodCapMessage implements IMessage
 	{
 		new PacketBuffer(buf).writeShort(((NBTTagShort) serializeNBT()).getShort());
 	}
+
 }

--- a/src/main/java/yeelp/scalingfeast/potion/PotionMetabolism.java
+++ b/src/main/java/yeelp/scalingfeast/potion/PotionMetabolism.java
@@ -9,6 +9,7 @@ import net.minecraft.potion.Potion;
 import net.minecraft.util.FoodStats;
 import net.minecraft.world.World;
 import yeelp.scalingfeast.ModConsts;
+import yeelp.scalingfeast.util.FoodCapModifierProvider;
 import yeelp.scalingfeast.util.FoodCapProvider;
 
 /**
@@ -32,11 +33,11 @@ public class PotionMetabolism extends PotionBase
 		{
 			EntityPlayer player = (EntityPlayer)entity;
 			FoodStats fs = player.getFoodStats();
-			if(fs.getFoodLevel() < player.getCapability(FoodCapProvider.capFoodStat, null).getMaxFoodLevel())
+			if(fs.getFoodLevel() < player.getCapability(FoodCapProvider.capFoodStat, null).getMaxFoodLevel(player.getCapability(FoodCapModifierProvider.foodCapMod, null)))
 			{
 				fs.setFoodLevel(fs.getFoodLevel() + 1);
 			}
-			else if(fs.getSaturationLevel() < player.getCapability(FoodCapProvider.capFoodStat, null).getMaxFoodLevel())
+			else if(fs.getSaturationLevel() < player.getCapability(FoodCapProvider.capFoodStat, null).getMaxFoodLevel(player.getCapability(FoodCapModifierProvider.foodCapMod, null)))
 			{
 				fs.setFoodSaturationLevel(fs.getSaturationLevel() + 1);
 			}

--- a/src/main/java/yeelp/scalingfeast/util/FoodCap.java
+++ b/src/main/java/yeelp/scalingfeast/util/FoodCap.java
@@ -35,15 +35,18 @@ public final class FoodCap implements IFoodCap
 	{
 		this.max = max;
 	}
-	/**
-	 * Get this container's maximum food level
-	 * @return this container's maximum food level
-	 */
-	public short getMaxFoodLevel()
+
+	
+	public short getMaxFoodLevel(IFoodCapModifier mod)
+	{
+		return (short) (Math.max(1, this.max + mod.getModifier()));
+	}
+
+	public short getUnmodifierMaxFoodLevel()
 	{
 		return this.max;
 	}
-
+	
 	public void setMax(short max)
 	{
 		if(max < 0)
@@ -129,7 +132,7 @@ public final class FoodCap implements IFoodCap
 		@Override
 		public NBTBase writeNBT(Capability<IFoodCap> capability, IFoodCap instance, EnumFacing side)
 		{
-			return new NBTTagShort(instance.getMaxFoodLevel());
+			return new NBTTagShort(instance.getUnmodifiedMaxFoodLevel());
 		}
 
 		@Override

--- a/src/main/java/yeelp/scalingfeast/util/FoodCapModifier.java
+++ b/src/main/java/yeelp/scalingfeast/util/FoodCapModifier.java
@@ -1,0 +1,104 @@
+package yeelp.scalingfeast.util;
+
+import java.util.concurrent.Callable;
+
+import net.minecraft.nbt.NBTBase;
+import net.minecraft.nbt.NBTTagShort;
+import net.minecraft.util.EnumFacing;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.Capability.IStorage;
+import net.minecraftforge.common.capabilities.CapabilityManager;
+
+/**
+ * A class that implements the IFoodCapModifier
+ * @author Yeelp
+ *
+ */
+public class FoodCapModifier implements IFoodCapModifier 
+{
+	private short mod;
+
+	/**
+	 * Create a new FoodCapModifier
+	 */
+	public FoodCapModifier()
+	{
+		this.mod = 0;
+	}
+	
+	/**
+	 * Create a new FoodCapModifer with the specified amount
+	 * @param mod the starting modifier
+	 */
+	public FoodCapModifier(short mod)
+	{
+		this.mod = mod;
+	}
+	
+	@Override
+	public boolean hasCapability(Capability<?> capability, EnumFacing facing)
+	{
+		return capability == FoodCapModifierProvider.foodCapMod;
+	}
+
+	@Override
+	public <T> T getCapability(Capability<T> capability, EnumFacing facing) 
+	{
+		return capability == FoodCapModifierProvider.foodCapMod ? FoodCapModifierProvider.foodCapMod.<T> cast(this) : null;
+	}
+
+	@Override
+	public NBTTagShort serializeNBT() 
+	{
+		return new NBTTagShort(this.mod);
+	}
+
+	@Override
+	public void deserializeNBT(NBTTagShort nbt)
+	{
+		this.mod = nbt.getShort();
+	}
+	
+	@Override
+	public short getModifier()
+	{
+		return mod;
+	}
+	
+	@Override
+	public void setModifier(short amount)
+	{
+		this.mod = amount;
+	}
+	
+	public static void register()
+	{
+		CapabilityManager.INSTANCE.register(IFoodCapModifier.class, new FoodModStorage(), new FoodModFactory());
+	}
+
+	public static class FoodModFactory implements Callable<IFoodCapModifier>
+	{
+		@Override
+		public IFoodCapModifier call() throws Exception 
+		{
+			return new FoodCapModifier();
+		}	
+	}
+	
+	public static class FoodModStorage implements IStorage<IFoodCapModifier>
+	{
+
+		@Override
+		public NBTBase writeNBT(Capability<IFoodCapModifier> capability, IFoodCapModifier instance, EnumFacing side) 
+		{
+			return new NBTTagShort(instance.getModifier());
+		}
+
+		@Override
+		public void readNBT(Capability<IFoodCapModifier> capability, IFoodCapModifier instance, EnumFacing side, NBTBase nbt) 
+		{
+			instance.setModifier(((NBTTagShort) nbt).getShort());
+		}
+		
+	}
+}

--- a/src/main/java/yeelp/scalingfeast/util/FoodCapModifierProvider.java
+++ b/src/main/java/yeelp/scalingfeast/util/FoodCapModifierProvider.java
@@ -1,0 +1,12 @@
+package yeelp.scalingfeast.util;
+
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.CapabilityInject;
+
+public class FoodCapModifierProvider 
+{
+	@CapabilityInject(IFoodCapModifier.class)
+	public static Capability<IFoodCapModifier> foodCapMod = null;
+	
+	private IFoodCapModifier instance = foodCapMod.getDefaultInstance();
+}

--- a/src/main/java/yeelp/scalingfeast/util/IFoodCap.java
+++ b/src/main/java/yeelp/scalingfeast/util/IFoodCap.java
@@ -12,9 +12,10 @@ public interface IFoodCap extends ICapabilitySerializable<NBTTagShort>
 {
 	/**
 	 * Get the max food level
+	 * @param mod the modifier to apply to this max hunger level
 	 * @return the max food level
 	 */
-	default short getMaxFoodLevel()
+	default short getMaxFoodLevel(IFoodCapModifier mod)
 	{
 		return 20;
 	}
@@ -23,7 +24,7 @@ public interface IFoodCap extends ICapabilitySerializable<NBTTagShort>
 	 * Get the max food level before modifications
 	 * @return the max food level, before any modifications
 	 */
-	default short getUnmodifiedMaxFoodLevel(FoodCapModifier mod)
+	default short getUnmodifiedMaxFoodLevel()
 	{
 		return 20;
 	}

--- a/src/main/java/yeelp/scalingfeast/util/IFoodCap.java
+++ b/src/main/java/yeelp/scalingfeast/util/IFoodCap.java
@@ -18,6 +18,15 @@ public interface IFoodCap extends ICapabilitySerializable<NBTTagShort>
 	{
 		return 20;
 	}
+	
+	/**
+	 * Get the max food level before modifications
+	 * @return the max food level, before any modifications
+	 */
+	default short getUnmodifiedMaxFoodLevel(FoodCapModifier mod)
+	{
+		return 20;
+	}
 	/**
 	 * Set the max food cap
 	 * @param maxLevel the level to set

--- a/src/main/java/yeelp/scalingfeast/util/IFoodCapModifier.java
+++ b/src/main/java/yeelp/scalingfeast/util/IFoodCapModifier.java
@@ -1,0 +1,27 @@
+package yeelp.scalingfeast.util;
+
+import net.minecraft.nbt.NBTTagShort;
+import net.minecraftforge.common.capabilities.ICapabilitySerializable;
+
+/**
+ * Capability for tracking food cap modifiers
+ * @author Yeelp
+ *
+ */
+public interface IFoodCapModifier extends ICapabilitySerializable<NBTTagShort>
+{
+	/**
+	 * Get the FoodCapModifier
+	 * @return the amount to modify food values by
+	 */
+	default short getModifier()
+	{
+		return 0;
+	}
+	
+	/**
+	 * Set the modifier value
+	 * @param amount
+	 */
+	void setModifier(short amount);
+}

--- a/src/main/java/yeelp/scalingfeast/util/SOLCarrotMilestone.java
+++ b/src/main/java/yeelp/scalingfeast/util/SOLCarrotMilestone.java
@@ -1,0 +1,74 @@
+package yeelp.scalingfeast.util;
+
+import squeek.applecore.api.AppleCoreAPI;
+
+/**
+ * A simple container for storing Spice of Life: Carrot Edition Milestones
+ * @author Yeelp
+ *
+ */
+public class SOLCarrotMilestone 
+{
+	private int milestoneTarget;
+	private short milestoneReward; 
+	/**
+	 * Create a new SOLCarrotMilestone
+	 * @param milestone A String of the form "m:r", where:
+	 * 
+	 * <p>- m represents an integer satisfying 0 < m and denotes the amount of food
+	 * eaten for this milestone
+	 * 
+	 * <p>- r represents an integer satisfying 0 < r < 32767 and denotes 
+	 * the amount of max hunger awarded at this milestone. In other words, r must be a valid positive short
+	 *
+	 * @throws IllegalArgumentException if milestone isn't a valid string that can be parsed, or if either m or r are non-positive
+	 * @throws NumberFormatException if the strings m and r can't be parsed as numbers.
+	 */
+	public SOLCarrotMilestone(String milestone) throws NumberFormatException, IllegalArgumentException
+	{
+		String[] arr = milestone.split(":");
+		if(arr.length != 2)
+		{
+			throw new IllegalArgumentException(milestone + " isn't a valid milestone!");
+		}
+		try
+		{
+			this.milestoneTarget = Integer.parseInt(arr[0]);
+			int temp = Integer.parseInt(arr[1]);
+			if(milestoneTarget <= 0)
+			{
+				throw new IllegalArgumentException(milestoneTarget+ " isn't a valid amount for a milestone!");
+			}
+			else if(temp <= 0)
+			{
+				throw new IllegalArgumentException(temp +" isn't a valid milestone reward amount!");
+			}
+			else
+			{
+				this.milestoneReward = (short)(Math.abs(temp) % 32768);
+			}
+		}
+		catch(NumberFormatException e)
+		{
+			throw e;
+		}
+	}
+	
+	/**
+	 * Get the amount needed for this milestone
+	 * @return the amount needed for this milestone
+	 */
+	public int getAmountNeeded()
+	{
+		return this.milestoneTarget;
+	}
+	
+	/**
+	 * Get the reward amount in half shanks for a player's max hunger due to reaching this milestone
+	 * @return the reward amount
+	 */
+	public short getReward()
+	{
+		return this.milestoneReward;
+	}
+}

--- a/src/main/java/yeelp/scalingfeast/util/SOLCarrotMilestone.java
+++ b/src/main/java/yeelp/scalingfeast/util/SOLCarrotMilestone.java
@@ -1,7 +1,5 @@
 package yeelp.scalingfeast.util;
 
-import squeek.applecore.api.AppleCoreAPI;
-
 /**
  * A simple container for storing Spice of Life: Carrot Edition Milestones
  * @author Yeelp

--- a/src/main/resources/assets/scalingfeast/lang/en_us.lang
+++ b/src/main/resources/assets/scalingfeast/lang/en_us.lang
@@ -4,6 +4,18 @@ commands.scalingfeast.command.existence=Player %s doesn't exist!
 commands.scalingfeast.command.numerr=Amount must be in range [0, %s)
 commands.scalingfeast.command.success=Success!
 
+modules.scalingfeast.sol.reward=You've gained %s max hunger!
+
+modules.scalingfeast.sol.splash0=Scrumptious!
+modules.scalingfeast.sol.splash1=What unique flavour!
+modules.scalingfeast.sol.splash2=Deeee-lish!
+modules.scalingfeast.sol.splash3=Delectable!
+modules.scalingfeast.sol.splash4=Yummy!
+modules.scalingfeast.sol.splash5=How savoury!
+modules.scalingfeast.sol.splash6=Succulent!
+modules.scalingfeast.sol.splash7=Tasty!
+
+
 
 enchantment.scalingfeast.fasting=Fasting
 enchantment.scalingfeast.gluttony=Gluttony


### PR DESCRIPTION
Drafting Scaling Feast integration with both versions of Spice of Life.

Successfully merging will close #29.

I've decided to add Spice of Life as a Git submodule for this task, as it didn't seem super feasible to be able to iterate over FoodEaten objects using reflection. If anything, it would've been super tedious and produce terribly unreadable source code.

SOLCarrot probably doesn't need a Git submodule, as it was fairly easy to use reflection to get the FoodList length, which is the only thing I need from it.