### PR TITLE
Improve FoodCapModifier

### DIFF
--- a/src/main/java/yeelp/scalingfeast/handlers/ModuleHandler.java
+++ b/src/main/java/yeelp/scalingfeast/handlers/ModuleHandler.java
@@ -179,7 +179,7 @@ public class ModuleHandler extends Handler
 		}
 		else
 		{
-			curr.setModifier(mod);
+			curr.setModifier("modules", mod);
 			//We want to use the current IFoodCapModifier we have. 
 			//We haven't synced it yet, and calling the convenience method from the API uses what's currently been synced, which is outdated.
 			short currMax = ScalingFeastAPI.accessor.getFoodCap(player).getMaxFoodLevel(curr);

--- a/src/main/java/yeelp/scalingfeast/util/FoodCapModifier.java
+++ b/src/main/java/yeelp/scalingfeast/util/FoodCapModifier.java
@@ -1,8 +1,13 @@
 package yeelp.scalingfeast.util;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.concurrent.Callable;
 
 import net.minecraft.nbt.NBTBase;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
 import net.minecraft.nbt.NBTTagShort;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.common.capabilities.Capability;
@@ -17,6 +22,7 @@ import net.minecraftforge.common.capabilities.CapabilityManager;
 public class FoodCapModifier implements IFoodCapModifier 
 {
 	private short mod;
+	private Map<String, Short> mods = new HashMap<String, Short>();
 
 	/**
 	 * Create a new FoodCapModifier
@@ -48,27 +54,62 @@ public class FoodCapModifier implements IFoodCapModifier
 	}
 
 	@Override
-	public NBTTagShort serializeNBT() 
+	public NBTTagList serializeNBT() 
 	{
-		return new NBTTagShort(this.mod);
+		NBTTagList lst = new NBTTagList();
+		for(Entry<String, Short> entry : mods.entrySet())
+		{
+			NBTTagCompound tag = new NBTTagCompound();
+			tag.setString("id", entry.getKey());
+			tag.setShort("modifier", entry.getValue());
+		}
+		return lst;
 	}
 
 	@Override
-	public void deserializeNBT(NBTTagShort nbt)
+	public void deserializeNBT(NBTBase nbt)
 	{
-		this.mod = nbt.getShort();
+		this.mods = new HashMap<String, Short>();
+		if(nbt instanceof NBTTagShort)
+		{
+			this.mods.put("modules", ((NBTTagShort) nbt).getShort());
+		}
+		else if(nbt instanceof NBTTagList)
+		{
+			NBTTagList lst = (NBTTagList) nbt;
+			if(lst.getTagType() == 10) //10 is the ID for NBTTagCompounds
+			{
+				for(NBTBase tag : lst)
+				{
+					NBTTagCompound modifier = (NBTTagCompound) tag;
+					this.mods.put(modifier.getString("id"), modifier.getShort("modifier"));
+				}
+			}
+		}
 	}
 	
 	@Override
 	public short getModifier()
 	{
+		short mod = 0;
+		for(short s : this.mods.values())
+		{
+			mod += s;
+		}
 		return mod;
 	}
 	
 	@Override
-	public void setModifier(short amount)
+	public short getModifier(String id)
 	{
-		this.mod = amount;
+		Short val = this.mods.get(id);
+		return val == null ? 0 : val.shortValue();
+	}
+	
+	@Override
+	public void setModifier(String id, short amount)
+	{
+		this.mods.put(id, amount);//this.mod = amount;
 	}
 	
 	public static void register()
@@ -91,13 +132,13 @@ public class FoodCapModifier implements IFoodCapModifier
 		@Override
 		public NBTBase writeNBT(Capability<IFoodCapModifier> capability, IFoodCapModifier instance, EnumFacing side) 
 		{
-			return new NBTTagShort(instance.getModifier());
+			return instance.serializeNBT();
 		}
 
 		@Override
 		public void readNBT(Capability<IFoodCapModifier> capability, IFoodCapModifier instance, EnumFacing side, NBTBase nbt) 
 		{
-			instance.setModifier(((NBTTagShort) nbt).getShort());
+			instance.deserializeNBT(nbt);
 		}
 		
 	}

--- a/src/main/java/yeelp/scalingfeast/util/IFoodCapModifier.java
+++ b/src/main/java/yeelp/scalingfeast/util/IFoodCapModifier.java
@@ -1,5 +1,6 @@
 package yeelp.scalingfeast.util;
 
+import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagShort;
 import net.minecraftforge.common.capabilities.ICapabilitySerializable;
 
@@ -8,11 +9,11 @@ import net.minecraftforge.common.capabilities.ICapabilitySerializable;
  * @author Yeelp
  *
  */
-public interface IFoodCapModifier extends ICapabilitySerializable<NBTTagShort>
+public interface IFoodCapModifier extends ICapabilitySerializable<NBTBase>
 {
 	/**
-	 * Get the FoodCapModifier
-	 * @return the amount to modify food values by
+	 * Get the final FoodCapModifier
+	 * @return the amount to modify food stats by
 	 */
 	default short getModifier()
 	{
@@ -20,8 +21,16 @@ public interface IFoodCapModifier extends ICapabilitySerializable<NBTTagShort>
 	}
 	
 	/**
+	 * Get a modifier by its id
+	 * @param id
+	 * @return the modifier associated with the id, or 0 if there was no modifier for this id.
+	 */
+	short getModifier(String id);
+	
+	/**
 	 * Set the modifier value
+	 * @param id identifier for this modifier amount
 	 * @param amount
 	 */
-	void setModifier(short amount);
+	void setModifier(String id, short amount);
 }


### PR DESCRIPTION
To implement Hunger Plus/Minus easily, I'd need to use the FoodCapModifier capability. However, the FoodCapModifier can't distinguish between the different modifiers (from modules, hunger plus/minus) which may cause errors in setting the final modifier value. This PR attempts to fix this while preserving compatibility with 1.4.0 and below.

- FoodCapModifiers now keep a map: String -> Short which differentiates modifier values by a String identifier.

- IFoodCapModifier now extends ICapabilitySerializable&lt;NBTBase&gt; as opposed to ICapabilitySerializable&lt;NBTTagShort&gt;. Now, Minecraft *should* attempt to read any type of NBT data when reading and writing NBT data for the FoodCapModifier. In particular, it can read BOTH NBTTagShort and NBTTagList.

- when deserializing  NBT data (Which now takes an NBTBase as an argument), we can check if this NBT tag is an instance of NBTTagShort. If so, get the stored short value (call it x) and put the entry ("modules", x) in the map (The ModuleHandler class now uses the identifier "modules" for it's modifier, which is the only class in v1.4.0 that uses the FoodCapModifier). This should successfully convert from the old storage to the new storage. If it's an instance of NBTTagList, we read it in the new format which is an NBTTagList of NBTTagCompounds, where each compound tag has a String and Short entry, which correspond to the id and modifier value respectively.

- When serializing NBT data, we serialize for the new format.

If this doesn't work (I hope this does as I have no ideas after this), I'm going to continue to document my attempts in this PR. If this DOES work, I'm merging this into the 1.5.0 dev branch.